### PR TITLE
Add MVPortal event

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,12 @@
         <dependency>
             <groupId>com.onarandombox.multiversecore</groupId>
             <artifactId>Multiverse-Core</artifactId>
-            <version>4.0.0</version>
+            <version>4.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.onarandombox.multiverseportals</groupId>
+            <artifactId>Multiverse-Portals</artifactId>
+            <version>4.1.0</version>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
Currently, when walking through a portal, the teleport event is not triggered (for some reason).
This adds the portal event to ensure you still get set to your previous location when using the portals.