### PR TITLE
Update regex validation

### DIFF
--- a/src/main/java/nl/zandervdm/stayput/Database/BaseDatabase.kt
+++ b/src/main/java/nl/zandervdm/stayput/Database/BaseDatabase.kt
@@ -31,7 +31,7 @@ open class BaseDatabase(val plugin: Main) {
     }
 
     fun isValidSQLIdentifier(s: String): Boolean {
-        val p = Pattern.compile("^[a-zA-Z_]{1,255}\$")
+        val p = Pattern.compile("^[a-zA-Z0-9_]{1,255}\$")
         return p.matcher(s).matches()
     }
 


### PR DESCRIPTION
The current regex did not allow numbers in the database name, which MySQL and MariaDB **do** allow.